### PR TITLE
Added script to set labels for all lab repos

### DIFF
--- a/labels/README.md
+++ b/labels/README.md
@@ -1,6 +1,6 @@
 # Shared labels
 This directory stores scripts and definitions of shared labels for all lab repositories, which can be applied to issues and PRs.
-The script can be used to set the same labels, including description and colours, across the organization to ensure consistency.
+The script can be used to set the same labels (defined at `labels.yaml`, including description and colours, across the organization to ensure consistency.
 
 ## Using the script
 First install dependencies.
@@ -11,7 +11,8 @@ In order to authenticate with GitHub, two things must be done:
 1. Use `gh auth` to authenticate with the CLI tool
 2. Generate a PAT with write access for the organization, and save it in the environment variable `$GITHUB_TOKEN`
 
-Now you can run `bash apply-labels.sh` which will set _all_ repos to have the same set of labels defined in `labels.yaml`.
+Now you can run `bash apply-labels.sh` which will perform a _dry run_, showing what it would have done.
+To actually set the labels, run `APPLY=true bash apply-labels.sh` which will set _all_ repos to have the same set of labels defined in `labels.yaml`.
 
 ## How does it work?
 This is a 3 step process:

--- a/labels/README.md
+++ b/labels/README.md
@@ -1,0 +1,20 @@
+# Shared labels
+This directory stores scripts and definitions of shared labels for all lab repositories, which can be applied to issues and PRs.
+The script can be used to set the same labels, including description and colours, across the organization to ensure consistency.
+
+## Using the script
+First install dependencies.
+- `Financial-Times/github-label-sync`, installed via `npm install github-label-sync`
+- The GitHub CLI tool `gh`, which should be installed following the instructions at `cli/cli`
+
+In order to authenticate with GitHub, two things must be done:
+1. Use `gh auth` to authenticate with the CLI tool
+2. Generate a PAT with write access for the organization, and save it in the environment variable `$GITHUB_TOKEN`
+
+Now you can run `bash apply-labels.sh` which will set _all_ repos to have the same set of labels defined in `labels.yaml`.
+
+## How does it work?
+This is a 3 step process:
+1. We call `gh api` using GraphQL to obtain a JSON file containing all the repos owned by the organization.
+2. We call `filter-repos.py` to filter out repos which are either archived, or have the `paper` tag. This spits out a text file, with each line containing the name of the repo that meets the criteria.
+3. Finally, we call `github-label-sync`, which sets the labels defined in the YAML file to all the repos in the organization. This relies on the PAT which must be defined.

--- a/labels/apply-labels.sh
+++ b/labels/apply-labels.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# this is inspired partially by
+# https://github.com/alphagov/design-system-team-labels
+
+# these are the files storing the repos
+ALL_REPOS=repos.json
+ACTIVE_REPOS=repos.txt
+LABELS_FILE=labels.yaml
+
+# for github-label-sync
+args=(
+  # --allow-added-labels # keep any existing labels that are not in the config
+  --labels $LABELS_FILE # we use yaml files
+)
+
+# Unless the APPLY environment variable is provided, just do a dry run and show
+# the changes that we would make.
+if [[ -z "$APPLY" ]]; then
+  args+=(--dry-run)
+fi
+
+# We exit if $GITHUB_TOKEN does not exist
+if [[ -z "$GITHUB_TOKEN" ]]; then
+  echo "The environment variable \$GITHUB_TOKEN needs to be defined" && exit 1
+fi
+
+# get all repos
+# this relies on an authenticated gh session
+gh api graphql -F owner='mdolab' -f query='
+  query($owner: String!) {
+    organization(login: $owner) {
+      repositories(first: 100) {
+        nodes {
+          nameWithOwner
+          isArchived
+          repositoryTopics(first: 100) {
+            nodes {
+              topic {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' | jq > $ALL_REPOS
+
+# filter out archived ones
+python filter-repos.py $ALL_REPOS $ACTIVE_REPOS
+
+# read the file and store in bash array
+readarray -t repos < $ACTIVE_REPOS
+
+for repo in ${repos[*]}; do
+  echo
+  echo "---"
+  echo "$repo"
+  echo "---"
+
+  npx github-label-sync -a "$GITHUB_TOKEN" "${args[@]}" "$repo"
+done

--- a/labels/filter-repos.py
+++ b/labels/filter-repos.py
@@ -1,0 +1,23 @@
+import json
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("filename", type=str, help="input JSON filename")
+parser.add_argument("output_filename", type=str, help="output txt filename")
+args = parser.parse_args()
+with open(args.filename) as f:
+    data = json.load(f)
+
+repos = []
+
+# remove archived repos
+# or ones with the 'paper' tag
+for d in data["data"]["organization"]["repositories"]["nodes"]:
+    if not d["isArchived"]:
+        topics = [t["topic"]["name"] for t in d["repositoryTopics"]["nodes"]]
+        if "paper" not in topics:
+            repos.append(d["nameWithOwner"])
+
+# write out the list
+with open(args.output_filename, mode="w") as f:
+    f.writelines("\n".join(repos) + '\n')

--- a/labels/labels.yaml
+++ b/labels/labels.yaml
@@ -1,0 +1,38 @@
+- name: "bug"
+  color: d73a4a
+  description: "Something isn't working"
+- name: "maintenance"
+  color: fbca04
+  description: "This is for maintaining the repo"
+  aliases:
+    - devops
+- name: "enhancement"
+  color: a2eeef
+  description: "New feature or request"
+- name: "question"
+  color: d876e3
+  description: "Further information is requested"
+- name: "discussion"
+  color: 1b83ae
+  description: "This needs to be discussed first"
+- name: "documentation"
+  color: 0075ca
+  description: "This is related to documentation"
+- name: "good first issue"
+  color: 7057ff
+  description: "Good for newcomers"
+- name: "help wanted"
+  color: 008672
+  description: "Extra attention is needed"
+- name: "wontfix"
+  color: ffffff
+  description: "This will not be worked on"
+- name: "duplicate"
+  color: cfd3d7
+  description: "This issue or pull request already exists"
+- name: "invalid"
+  color: e4e669
+  description: "This doesn't seem right"
+- name: "installation"
+  color: 2b64a9
+  description: "This is related to installation of the package"


### PR DESCRIPTION
## Purpose
I added some scripts along with a YAML file, which can be used to set a standard set of labels across all organizational repos.
I've run the script manually already, but decided to archive the script here in case it's needed in the future. In any case, having the YAML file around is handy if we want to tweak the labels.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)
