### PR TITLE
Added isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[isort]
+profile=black
+line_length=120
+force_sort_within_sections=true
+import_heading_stdlib=Standard Python modules
+import_heading_thirdparty=External modules
+import_heading_firstparty=First party modules
+import_heading_localfolder=Local modules

--- a/azure/README.md
+++ b/azure/README.md
@@ -14,6 +14,7 @@ The templates are organized into the following files:
 | :---        | :---- | :----  |               :--- |
 | `REPO_NAME`   | string |         | Name of repository |
 | `IGNORE_STYLE`| boolean | `false`| Allow black and flake8 jobs to fail without failing the pipeline |
+| `IGNORE_ISORT`| boolean | `true`| Skips the `isort` jobs |
 | `COMPLEX` | boolean | `false` | Flag for triggering complex build and tests |
 | `GCC_CONFIG` | string | `None` | Path to gcc configuration file (from repository root) |
 | `INTEL_CONFIG` | string | `None` | Path to intel configuration file (from repository root) |

--- a/azure/azure_style.yaml
+++ b/azure/azure_style.yaml
@@ -52,3 +52,17 @@ jobs:
           cd ${{ parameters.REPO_NAME }}
           pip install black==20.8b1
           black . --check --diff -l 120 --target-version py37 --target-version py38
+
+  - job: isort
+    pool:
+      vmImage: "ubuntu-20.04"
+    continueOnError: ${{ parameters.IGNORE_ISORT }}
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: "3.8"
+      - script: |
+          cd ${{ parameters.REPO_NAME }}
+          cp ../.github/.isort.cfg .
+          pip install isort
+          isort . -c

--- a/azure/azure_style.yaml
+++ b/azure/azure_style.yaml
@@ -56,8 +56,10 @@ jobs:
   - job: isort
     pool:
       vmImage: "ubuntu-20.04"
-    continueOnError: ${{ parameters.IGNORE_ISORT }}
+    condition: not(${{ parameters.IGNORE_ISORT }})
     steps:
+      - checkout: self
+      - checkout: azure_template
       - task: UsePythonVersion@0
         inputs:
           versionSpec: "3.8"

--- a/azure/azure_template.yaml
+++ b/azure/azure_template.yaml
@@ -4,6 +4,9 @@ parameters:
   - name: IGNORE_STYLE
     type: boolean
     default: false
+  - name: IGNORE_ISORT
+    type: boolean
+    default: true
   - name: COMPLEX
     type: boolean
     default: false
@@ -75,3 +78,4 @@ stages:
         parameters:
           REPO_NAME: ${{ parameters.REPO_NAME }}
           IGNORE_STYLE: ${{ parameters.IGNORE_STYLE }}
+          IGNORE_ISORT: ${{ parameters.IGNORE_ISORT }}


### PR DESCRIPTION
## Purpose
This PR adds a new job called `isort` which checks for correct sorting of python imports. Note that this is disabled by default. I also added a default configuration file `.isort.cfg` which is used to configure `isort`.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)
