### PR TITLE
Added optional coverage reporting step

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -25,6 +25,7 @@ The templates are organized into the following files:
 | `IMAGE` | string | `public` | Select docker image. Can be `public`, `private`, or `auto`. `auto` uses the private image on trusted builds and the public image otherwise. |
 | `SKIP_TESTS` | boolean | `false` | Skip all builds and tests |
 | `TIMEOUT` | number | `0` (this will use the full 360 minutes) | Runtime allowed for a job, in minutes |
+| `COVERAGE` | boolean | `false` | Flag to report test coverage to `codecov` |
 
 
 ## Setting up a pipeline

--- a/azure/azure_build.yaml
+++ b/azure/azure_build.yaml
@@ -13,6 +13,8 @@ parameters:
     type: string
   - name: TIMEOUT
     type: number
+  - name: COVERAGE
+    type: boolean
 
 jobs:
   - job:
@@ -65,3 +67,7 @@ jobs:
       - script: docker exec -e AGENT_NAME="$AGENT_NAME" app /bin/bash -c ". ${{ variables.BASHRC }} && cd ${{ variables.DOCKER_WORKING_DIR }} && /bin/bash ${{ parameters.TEST }}"
         displayName: Run Tests
         condition: ne('${{ parameters.TEST }}', 'None')
+      - script: |
+          ci_env=`bash <(curl -s https://codecov.io/env)`
+          docker exec $ci_env -e CI=true app /bin/bash -c ". ${{ variables.BASHRC }} && cd ${{ variables.DOCKER_WORKING_DIR }} && bash <(curl -s https://codecov.io/bash)"
+        condition: ${{ parameters.COVERAGE }}

--- a/azure/azure_template.yaml
+++ b/azure/azure_template.yaml
@@ -37,6 +37,9 @@ parameters:
   - name: TIMEOUT
     type: number
     default: 0
+  - name: COVERAGE
+    type: boolean
+    default: false
 
 stages:
   - stage: Test_Real
@@ -53,6 +56,7 @@ stages:
           TEST: ${{ parameters.TEST_REAL }}
           IMAGE: ${{ parameters.IMAGE }}
           TIMEOUT: ${{ parameters.TIMEOUT }}
+          COVERAGE: ${{ parameters.COVERAGE }}
 
   - stage: Test_Complex
     dependsOn: []
@@ -68,6 +72,7 @@ stages:
           TEST: ${{ parameters.TEST_COMPLEX }}
           IMAGE: ${{ parameters.IMAGE }}
           TIMEOUT: ${{ parameters.TIMEOUT }}
+          COVERAGE: ${{ parameters.COVERAGE }}
 
   - stage: Style
     dependsOn: []


### PR DESCRIPTION
## Purpose
This PR adds an optional coverage reporting step, enabled via the `COVERAGE` parameter. Closes #1.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)
