### PR TITLE
Update build matrix

### DIFF
--- a/azure/azure_build.yaml
+++ b/azure/azure_build.yaml
@@ -23,9 +23,6 @@ jobs:
     timeoutInMinutes: ${{ parameters.TIMEOUT }}
     strategy:
       matrix:
-        "c7-gcc-ompi-latest":
-          DOCKER_TAG: c7-gcc-ompi-latest
-          CONFIG_FILE: ${{ parameters.GCC_CONFIG }}
         "c7-intel-impi-latest":
           DOCKER_TAG: c7-intel-impi-latest
           CONFIG_FILE: ${{ parameters.INTEL_CONFIG }}

--- a/azure/azure_build.yaml
+++ b/azure/azure_build.yaml
@@ -32,6 +32,9 @@ jobs:
         "u20-gcc-ompi-stable":
           DOCKER_TAG: u20-gcc-ompi-stable
           CONFIG_FILE: ${{ parameters.GCC_CONFIG }}
+        "tacc-u18-gcc-impi-stable":
+          DOCKER_TAG: tacc-u18-gcc-impi-stable
+          CONFIG_FILE: ${{ parameters.GCC_CONFIG }}
     variables:
       - group: Docker
       - name: MDOLAB_HOMEDIR


### PR DESCRIPTION
## Purpose
I removed the `c7-gcc-ompi-latest` build since it's deprecated. Do we want to test any of the other images? Perhaps `tacc-u18-gcc-impi-stable`?