### PR TITLE
Codecov configuration fix

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,6 @@ coverage:
     project:
       default:
         threshold: 5%
+    patch:
+      default:
+        target: 50%

--- a/azure/azure_build.yaml
+++ b/azure/azure_build.yaml
@@ -46,7 +46,14 @@ jobs:
       - name: BASHRC
         value: ${{ variables.MDOLAB_HOMEDIR }}/.bashrc_mdolab
     steps:
+      - checkout: self
+      - checkout: azure_template
       - script: |
+          # Copy the common Codecov configuration file if none exists
+          if [[ ! -f "${{ parameters.REPO_NAME }}/.codecov.yml" ]]; then
+            cp .github/.codecov.yml ${{ parameters.REPO_NAME }}
+          fi
+
           # This is a trusted build if DOCKER_USERNAME is defined
           if [[ ! -z $(DOCKER_USERNAME) ]] ; then
             echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_USERNAME) --password-stdin;
@@ -58,7 +65,7 @@ jobs:
             export DOCKER_REPO=public;
           fi
           docker pull mdolab/$DOCKER_REPO:$(DOCKER_TAG);
-          docker run -t -d --name app --mount "type=bind,src=$(pwd),target=${{ variables.DOCKER_MOUNT_DIR }}" mdolab/$DOCKER_REPO:$(DOCKER_TAG) /bin/bash;
+          docker run -t -d --name app --mount "type=bind,src=$(pwd)/${{ parameters.REPO_NAME }},target=${{ variables.DOCKER_MOUNT_DIR }}" mdolab/$DOCKER_REPO:$(DOCKER_TAG) /bin/bash;
           docker exec app /bin/bash -c "rm -rf ${{ variables.DOCKER_WORKING_DIR }} && cp -r ${{ variables.DOCKER_MOUNT_DIR }} ${{ variables.DOCKER_WORKING_DIR }}"
         displayName: Prepare Repository
       - script: docker exec -e CONFIG_FILE=$(CONFIG_FILE) app /bin/bash -c ". ${{ variables.BASHRC }} && cd ${{ variables.DOCKER_WORKING_DIR }} && /bin/bash ${{ parameters.BUILD }}"


### PR DESCRIPTION
## Purpose
These changes are to make the tests use the global Codecov configuration file in this repo:
- `azure_build.yaml` now checks out the `.github` repo, which changes the directory structure slightly
- the Codecov yaml is copied over before the Docker mount step

I also updated the Codecov patch default to 50%, meaning that the patch status will be a success if at least 50% of the lines modified in a PR are tested.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
