### PR TITLE
Fully automate `buildbot_setup.sh`

### DIFF
--- a/build-bot/buildbot_setup.sh
+++ b/build-bot/buildbot_setup.sh
@@ -36,7 +36,7 @@ sudo apt-get -y install docker-ce docker-ce-cli containerd.io
 # add docker to the sudo group
 sudo groupadd docker -f
 sudo usermod -aG docker $USER
-newgrp docker
+newgrp docker <<BLAH
 echo ""
 echo ""
 echo ""
@@ -55,6 +55,7 @@ echo ""
 echo "Enabling docker service"
 sudo systemctl enable docker.service
 sudo systemctl enable containerd.service
+BLAH
 echo ""
 echo ""
 echo ""

--- a/build-bot/buildbot_setup.sh
+++ b/build-bot/buildbot_setup.sh
@@ -36,13 +36,13 @@ sudo apt-get -y install docker-ce docker-ce-cli containerd.io
 # add docker to the sudo group
 sudo groupadd docker -f
 sudo usermod -aG docker $USER
-newgrp docker <<BLAH
+
 echo ""
 echo ""
 echo ""
 echo "Testing that docker works"
 # test that docker works
-docker run hello-world
+sudo docker run hello-world
 if [ $? -ne 0 ]; then
     echo "Docker was not installed correctly"
     exit 1
@@ -55,7 +55,7 @@ echo ""
 echo "Enabling docker service"
 sudo systemctl enable docker.service
 sudo systemctl enable containerd.service
-BLAH
+
 echo ""
 echo ""
 echo ""
@@ -92,3 +92,4 @@ echo ""
 echo ""
 echo ""
 echo "SETUP COMPLETE"
+newgrp docker


### PR DESCRIPTION
## Purpose
For some reason that I don't understand, running the `newgrp` command (required to allow docker to be run without sudo) will end a shell script. I therefore moved the `newgrp` command to the end of the script and run the docker hello-world test in the script as sudo.

This means the buildbot setup script is now **FULLY AUTOMATED**
