### PR TITLE
Adding option to enable clang formatting

### DIFF
--- a/azure/azure_style.yaml
+++ b/azure/azure_style.yaml
@@ -10,6 +10,9 @@ parameters:
   - name: PYLINT
     type: boolean
     default: false # these defaults are here because the template could be used by repos directly
+  - name: CLANG_FORMAT
+    type: boolean
+    default: false # these defaults are here because the template could be used by repos directly
 
 jobs:
   - job: flake8
@@ -100,3 +103,14 @@ jobs:
 
           pip install pylint
           find . -type f -name "*.py" -not -path "*/doc/*" | xargs pylint
+
+  - job: clang-format
+      pool:
+        vmImage: "ubuntu-20.04"
+      condition: ${{ parameters.CLANG_FORMAT }}
+      steps:
+        - script: |
+            cd ${{ parameters.REPO_NAME }}
+            sudo apt-get install clang-format -y
+            bash ./.github/clang_format.sh
+

--- a/azure/azure_template.yaml
+++ b/azure/azure_template.yaml
@@ -52,6 +52,9 @@ parameters:
   - name: TAPENADE_VERSION
     type: string
     default: 3.10
+  - name: CLANG_FORMAT
+    type: boolean
+    default: false
 
 stages:
   - stage: Test_Real
@@ -97,6 +100,7 @@ stages:
           IGNORE_STYLE: ${{ parameters.IGNORE_STYLE }}
           ISORT: ${{ parameters.ISORT }}
           PYLINT: ${{ parameters.PYLINT }}
+          CLANG_FORMAT: ${{ parameters.CLANG_FORMAT }}
 
   - stage: Tapenade
     dependsOn: []


### PR DESCRIPTION
## Purpose
Add an option that can be used if clang-format is supposed to be run. This could be included to https://github.com/mdolab/tacs_orig/pull/77 as part of that PR. 

The PR does not include the formatting input file `.clang-format`, but it could. At the moment, its expected to live in the repository itself. See https://github.com/mdolab/tacs_orig/pull/77 that contains a custom file. We could include it here as the default set, and do some check and use the repo one if it exists (similar to flake8).

<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->

## Expected time until merged
No urgency.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
