### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -58,7 +58,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true


### PR DESCRIPTION
I just realised that we were using `DerivePointerAlignment: true` in clang-format, which to me goes against the whole purpose of running a formatter. I propose we set this to false so that we actually enforce a global rule on pointer alignment.