### PR TITLE
More C code coverage and flake8 update

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,6 +15,8 @@ extend-ignore =
     W605,
     # line length, exceeded by some docstrings
     E501,
+    # Function definition does not bind loop variable, happens everywhere in our code
+    B023,
 
 select =
     # ===== built-in checks

--- a/azure/azure_build.yaml
+++ b/azure/azure_build.yaml
@@ -155,8 +155,9 @@ jobs:
           lcov --capture --directory . --output-file coverage.info && \
           lcov --remove coverage.info '/usr/*' --output-file coverage.info && \
           lcov --remove coverage.info '*/numpy/*' --output-file coverage.info && \
-          lcov --remove coverage.info '*/.pyenv/versions' --output-file coverage.info && \
-          lcov --remove coverage.info '*mpi4py*' --output-file coverage.info"
+          lcov --remove coverage.info '*/.pyenv/versions/*' --output-file coverage.info && \
+          lcov --remove coverage.info '*mpi4py*' --output-file coverage.info" && \
+          lcov --list coverage.info
 
           # copy coverage file out of Docker
           docker cp app:${{ variables.DOCKER_WORKING_DIR }}/coverage.info $(pwd)


### PR DESCRIPTION
## Purpose
The .pyenv directory is still being checked for coverage so this will hopefully fix that. Another line has been added to print a table of coverage before it is uploaded to codecov

## Expected time until merged
fast 

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Tested with new TACS build after this is merged

## Checklist
- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
