### PR TITLE
Refactor fprettify and clang-format style checks to scripts to make use of it for local formatting

### DIFF
--- a/.fprettify.rc
+++ b/.fprettify.rc
@@ -1,7 +1,7 @@
 [fprettify]
 
-i=4
-l=120
+indent=4
+line-length=120
 whitespace-multdiv
 strict-indent
 enable-decl

--- a/azure/azure_style.yaml
+++ b/azure/azure_style.yaml
@@ -149,26 +149,17 @@ jobs:
       - script: |
           cd ${{ parameters.REPO_NAME }}
 
-          # If there is no local config file, copy over the global config file
-          if [[ ! -f ".fprettify.rc" ]]; then
-            cp ../.github/.fprettify.rc .
+          # Check if we can access script, if not exit immediate
+          if [[ ! -f ../.github/azure/fprettify.sh ]]; then
+            echo "fprettify.sh not found. Exiting."
+            exit 1
           fi
 
           # Install fprettify
           pip install fprettify==0.3.7
 
-          # Run fprettify on non-differentiated Fortran 90 source files
-          find . -type f -iname '*.f90' ! -iname '*_b.f90' ! -iname '*_d.f90' -print0 | while read -d $'\0' file
-          do
-            echo Checking $file
-            fprettify $file
-
-            # Check if this file changed and print a message if it did
-            git diff --summary --exit-code $file
-            if [ $? -ne 0 ]; then
-              echo $file needs to be formatted
-            fi
-          done
+          # Run the formatting
+          bash ../.github/azure/fprettify.sh . || exit $?
 
           # Exit with an error if any of the tracked files changed
           git diff --summary --exit-code

--- a/azure/azure_style.yaml
+++ b/azure/azure_style.yaml
@@ -128,12 +128,14 @@ jobs:
 
           cd ${{ parameters.REPO_NAME }}
 
-          # if no local file is found in the repository, copy over the global .clang-format config file
-          if [[ ! -f ".clang-format" ]]; then
-            cp ../.github/.clang-format . || exit 1
+          # Check if we can access script, if not exit
+          if [[ ! -f ../.github/azure/clang-format.sh ]]; then
+            echo "clang-format.sh .sh not found. Exiting."
+            exit 1
           fi
 
-          find . -iname '*.h' -o -iname '*.hpp' -o -iname '*.c' -o -iname '*.cpp' | xargs clang-format --verbose --dry-run --Werror -style=file
+          # Run the formatting
+          bash ../.github/azure/clang-format.sh --dry-run || exit $?
 
   - job: fprettify
     pool:
@@ -149,7 +151,7 @@ jobs:
       - script: |
           cd ${{ parameters.REPO_NAME }}
 
-          # Check if we can access script, if not exit immediate
+          # Check if we can access script, if not exit
           if [[ ! -f ../.github/azure/fprettify.sh ]]; then
             echo "fprettify.sh not found. Exiting."
             exit 1
@@ -159,7 +161,7 @@ jobs:
           pip install fprettify==0.3.7
 
           # Run the formatting
-          bash ../.github/azure/fprettify.sh . || exit $?
+          bash ../.github/azure/fprettify.sh || exit $?
 
           # Exit with an error if any of the tracked files changed
           git diff --summary --exit-code

--- a/azure/azure_style.yaml
+++ b/azure/azure_style.yaml
@@ -130,7 +130,7 @@ jobs:
 
           # Check if we can access script, if not exit
           if [[ ! -f ../.github/azure/clang-format.sh ]]; then
-            echo "clang-format.sh .sh not found. Exiting."
+            echo "clang-format.sh not found. Exiting."
             exit 1
           fi
 

--- a/azure/clang-format.sh
+++ b/azure/clang-format.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# clang-format expects a .clang-format file in the root (local dir) where the command
+# is run. Need to check for existing files first. If none copy over the global file
+# and remove once done to make sure its not added to git.
+
+# -------------- Command line input --------------
+USAGE="
+usage: [-d]
+
+Argument description:
+    -d|--dry-run    Do not make changes, only simulate formatting changes
+"
+DRY_RUN=""
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -d|--dry-run) DRY_RUN="--dry-run"; shift ;;
+        -h|--help) echo "$USAGE";  exit 1 ;;
+        *) echo "Unknown parameter passed: $1"; echo "$USAGE"; exit 1 ;;
+    esac
+    shift
+done
+
+# Set some constants
+CLANGFORMAT_CONFIG_FILE=""
+LOCAL_CONFIG_FILE=".clang-format"
+GLOBAL_CONFIG_FILE="../.github/.clang-format"
+
+# Initialize variables
+global=0
+
+if [[ -f "$LOCAL_CONFIG_FILE" ]]; then
+    # Use local config file
+    echo "Using local config file: $LOCAL_CONFIG_FILE"
+    CLANGFORMAT_CONFIG_FILE="$LOCAL_CONFIG_FILE"
+elif [[ -f "$GLOBAL_CONFIG_FILE" ]]; then
+    # Use global config file
+    echo "Using .github shared config file: $GLOBAL_CONFIG_FILE"
+    CLANGFORMAT_CONFIG_FILE="$GLOBAL_CONFIG_FILE"
+    cp "$GLOBAL_CONFIG_FILE" .
+    global=1
+else
+    echo "No clang-format config was found. Exiting"
+    exit 2
+fi
+
+# Setting common values
+clang_format_args="-style=file --verbose --Werror"
+if [[ -z "$DRY_RUN" ]]; then
+    # Apply the formatting inplace
+    clang_format_args="$clang_format_args -i"
+else
+    # Only do a dry run
+    clang_format_args="$clang_format_args --dry-run"
+fi
+
+echo "Running clang-format with args: $clang_format_args"
+
+# Run the formatting
+find . -iname '*.h' -o -iname '*.hpp' -o -iname '*.c' -o -iname '*.cpp' | xargs clang-format $clang_format_args
+
+# Store the exit code in case we are running dry-run and find
+clang_exit_code=$?
+
+if [[ 1 == "$global" ]]; then
+    # Remove only of we copied over
+    rm "$LOCAL_CONFIG_FILE"
+fi
+
+exit $clang_exit_code

--- a/azure/fprettify.sh
+++ b/azure/fprettify.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+FPRETTIFY_CONFIG_FILE=""
+LOCAL_CONFIG_FILE=".fprettify.rc"
+GLOBAL_CONFIG_FILE="../.github/.fprettify.rc"
+
+if [[ ! -z "$1" ]]; then
+    # Offer the option of supplying config file through an argument
+    echo "Using user supplied fprettify config file: $1"
+    FPRETTIFY_CONFIG_FILE="$1"
+elif [[ -f "$LOCAL_CONFIG_FILE" ]]; then
+    # Use local config file
+    echo "Using local fprettify config file: $LOCAL_CONFIG_FILE"
+    FPRETTIFY_CONFIG_FILE="$LOCAL_CONFIG_FILE"
+elif [[ -f "$GLOBAL_CONFIG_FILE" ]]; then
+    # Use global config file
+    echo "Using .github shared fprettify config file: $GLOBAL_CONFIG_FILE"
+    FPRETTIFY_CONFIG_FILE="$GLOBAL_CONFIG_FILE"
+else
+    echo "No fprettify config was found. Exiting"
+    exit 2
+fi
+
+# Run fprettify on non-differentiated Fortran 90 source files
+find . -type f -iname '*.f90' ! -iname '*_b.f90' ! -iname '*_d.f90' -print0 | while read -d $'\0' fileName
+do
+    echo "Checking $fileName"
+    fprettify --config-file "$FPRETTIFY_CONFIG_FILE" "$fileName"
+
+    # Check if this file changed and print a message if it did
+    git diff --summary --exit-code $fileName
+    if [ $? -ne 0 ]; then
+        echo "$fileName was formatted"
+    fi
+done


### PR DESCRIPTION
## Purpose
Refactored the fprettify and clang-format calls such that they can both be used for testing and locally. This allows us to quickly run the formatting locally in a consistent way with what we do for testing.

## Expected time until merged
Few days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Try the `fprettify.sh` and `clang-format.sh` scripts locally on different repositories to test.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
