### PR TITLE
Enable flake8-rst-docstrings checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,8 +19,6 @@ extend-ignore =
     B023,
     # pydocstyle
     D
-    # flake8-rst-docstrings
-    RST
 
 # Only add patterns here that are not included by the defaults of flake8 or other plugins
 # extend-select =


### PR DESCRIPTION
## Purpose
Noticed that many of our repos have a broken API documentation, see [here](https://mdolab-pyspline.readthedocs-hosted.com/en/latest/API/utils.html#pyspline.utils.writeTecplot3D) for example.
Enabling the `flake8-rst-docstrings` should address this.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
