### PR TITLE
Remove TACC images from test matrix

### DIFF
--- a/azure/azure_build.yaml
+++ b/azure/azure_build.yaml
@@ -34,9 +34,6 @@ jobs:
         "u20-gcc-ompi-stable":
           DOCKER_TAG: u20-gcc-ompi-stable
           CONFIG_FILE: ${{ parameters.GCC_CONFIG }}
-        "tacc-u18-gcc-impi-stable":
-          DOCKER_TAG: tacc-u18-gcc-impi-stable
-          CONFIG_FILE: ${{ parameters.GCC_CONFIG }}
     variables:
       - group: Docker
       - group: Codecov
@@ -71,13 +68,7 @@ jobs:
         condition: and(succeeded(), ne('${{ parameters.BUILD }}', 'None'))
       - script: |
           set -e
-          # Source the IMPI setup script on the TACC image
-          if [[ "$(DOCKER_TAG)" =~ "tacc" ]] ; then
-            export TACC_IMPI=". \$HOME/set_local_impi_vars.sh"
-          else
-            export TACC_IMPI=":"
-          fi
-          docker exec -e AGENT_NAME="$AGENT_NAME" -e BUILD_REASON=$(Build.Reason) app /bin/bash -c ". ${{ variables.BASHRC }} && $TACC_IMPI && cd ${{ variables.DOCKER_WORKING_DIR }} && /bin/bash ${{ parameters.TEST }}"
+          docker exec -e AGENT_NAME="$AGENT_NAME" -e BUILD_REASON=$(Build.Reason) app /bin/bash -c ". ${{ variables.BASHRC }} && cd ${{ variables.DOCKER_WORKING_DIR }} && /bin/bash ${{ parameters.TEST }}"
         displayName: Run Tests
         condition: and(succeeded(), ne('${{ parameters.TEST }}', 'None'))
       - script: |


### PR DESCRIPTION
## Purpose
TACC Stampede2 images are outdated and will not be built past PR https://github.com/mdolab/docker/pull/264. This PR removes them from the testing matrix.

## Expected time until merged
No rush.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
