### PR TITLE
Updating github runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   black:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable

--- a/.github/workflows/clang_format.yaml
+++ b/.github/workflows/clang_format.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   clang_format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   flake8:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [3.9, 3.11]

--- a/.github/workflows/isort.yaml
+++ b/.github/workflows/isort.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   isort:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   mypy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [3.9, 3.11]

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   pylint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   pypi:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Purpose
GitHub is [deprecating](https://github.com/actions/runner-images/issues/11101) the Ubuntu 20.04 runners. Deprecation will begin on 2025-02-01 and the image will be fully unsupported by 2025-04-01.

This PR updates the runners to use Ubuntu 24.04. We could also use `ubunut-latest`, for whatever the latest Ubuntu image is. It might however raise some unexpected fails later, which is why the image version is set explicitly.

## Expected time until merged
Before deadline.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
