### PR TITLE
Exclude Tapenade generated files from pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
-exclude: ^.*\.(cgns|CGNS)$
+# pre-commit doesn't recognize cgns files as binary and tries to format them, so we need to exclude them.
+# Also exclude Tapenade-generated Fortran files (ending with _d.f90 or _b.f90 in our codes) because we run checks that expect these files to be exactly as Tapenade generated them.
+exclude: |
+            (?x)^(
+                .*\.cgns|
+                ^src\/.*_d\.f90|
+                ^src\/.*_b\.f90
+            )$
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Necessary so that pre-commit doesn't alter tapenade generated files in a way that causes our tapenade checks to fail. We already do the same thing for our [fprettify check](https://github.com/mdolab/.github/blob/cb145eb5adcc796c884f3ac1027568d11ca11f78/azure/fprettify.sh#L25)

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
